### PR TITLE
Add GITHUB_TOKEN to Maven release arguments

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -50,7 +50,7 @@ jobs:
             -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
             -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
             -DscmCommentPrefix="[release] " \
-            -Darguments="-DskipTests"
+            -Darguments="-DskipTests -Denv.GITHUB_TOKEN=${{ secrets.RELEASE_TOKEN }}"
         working-directory: fashion-app-mongodb
 
       - name: Generate Release Notes


### PR DESCRIPTION
### What does this PR do?
Fixes Maven Release workflow to resolve 401 Unauthorized error when deploying artifacts to GitHub Packages.

### Related issue
Closes #8

### Description for the changelog
```markdown changelog
Fix Maven Release workflow authentication for GitHub Packages deployment
```