### PR TITLE
Add Docker publish workflow and Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: fashion-app-mongodb
 
   build:
-    name: Build and Unit Tests
+    name: Build
     runs-on: ubuntu-latest
     needs: static-analysis
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,3 +87,7 @@ jobs:
         with:
           name: failsafe-reports
           path: fashion-app-mongodb/target/failsafe-reports/
+
+  docker:
+    needs: build
+    uses: ./.github/workflows/docker-publish.yml

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,41 @@
+name: Docker Publish
+
+on:
+  workflow_call:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/fashion-app-mongodb/deploy/Dockerfile
+++ b/fashion-app-mongodb/deploy/Dockerfile
@@ -1,0 +1,22 @@
+FROM maven:3.9.9-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+COPY checkstyle.xml .
+
+RUN mvn -B -q -e -DskipTests dependency:go-offline
+
+COPY src ./src
+
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/fashion-app-mongodb/deploy/Dockerfile.dockerignore
+++ b/fashion-app-mongodb/deploy/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+node_modules
+target/
+Dockerfile
+docker-compose.yml
+*.log
+.env
+.vscode
+.idea


### PR DESCRIPTION
### What does this PR do?

Adds Docker support and automated container publishing for the Fashion Management Application.

This PR introduces:
- Multi-stage Java 17 Docker build at `deploy/Dockerfile`
- Version-independent JAR copy pattern for stable Docker builds
- Docker build context optimization via `deploy/Dockerfile.dockerignore`
- GitHub Actions workflow for building and publishing Docker images to GitHub Container Registry (`ghcr.io`)
- Automatic image tagging using branch name, commit SHA, and `latest` for the default branch
- Integration of Docker publishing into the main CI pipeline after successful build completion
- Required GitHub Actions permissions for package publishing

The Docker image now packages and runs the Spring Boot application (`com.fashion.FashionApplication`) in a containerized environment.

### Related issue

Closes #<issue-number>

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Added Docker build and automated GitHub Container Registry publishing workflow for the Fashion Management Application.