### PR TITLE
Add Playwright E2E tests and dependency

### DIFF
--- a/fashion-app-mongodb/deploy/Dockerfile
+++ b/fashion-app-mongodb/deploy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY pom.xml .
 COPY checkstyle.xml .
 
-RUN mvn -B -q -e -DskipTests dependency:go-offline
+RUN mvn -B -q -e -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.6.1:go-offline
 
 COPY src ./src
 

--- a/fashion-app-mongodb/pom.xml
+++ b/fashion-app-mongodb/pom.xml
@@ -46,8 +46,6 @@
       <version>2.5.4</version>
       <scope>test</scope>
     </dependency>
-    <!-- Testcontainers for integration tests -->
-    <!-- Testcontainers для integration tests -->
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
@@ -58,6 +56,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>1.20.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.52.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/fashion-app-mongodb/src/test/java/com/fashion/e2e/FashionE2ETest.java
+++ b/fashion-app-mongodb/src/test/java/com/fashion/e2e/FashionE2ETest.java
@@ -1,0 +1,163 @@
+package com.fashion.e2e;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+public class FashionE2ETest {
+
+    private static Playwright playwright;
+    private static Browser browser;
+    private static Page page;
+
+    private static final String BASE_URL =
+            System.getProperty(
+                    "E2E_BASE_URL",
+                    System.getenv("E2E_BASE_URL")
+            );
+
+    @BeforeAll
+    static void setup() {
+
+        Assumptions.assumeTrue(
+                BASE_URL != null && !BASE_URL.isBlank(),
+                "E2E_BASE_URL is not set. Skipping E2E tests."
+        );
+
+        playwright = Playwright.create();
+
+        browser = playwright.chromium().launch(
+                new BrowserType.LaunchOptions()
+                        .setHeadless(true)
+        );
+
+        page = browser.newPage();
+    }
+
+    @AfterAll
+    static void tearDown() {
+
+        if (page != null) {
+            page.close();
+        }
+
+        if (browser != null) {
+            browser.close();
+        }
+
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @Test
+    void shouldOpenMainSchedulePage() {
+
+        page.navigate(BASE_URL);
+
+        page.waitForLoadState();
+        page.waitForTimeout(3000);
+
+        assertThat(page).hasTitle("Fashion Management");
+
+        assertThat(page.locator("h1"))
+                .containsText("Fashion Management");
+
+        assertThat(page.locator(".btn-add"))
+                .containsText("Add Record");
+    }
+
+    @Test
+    void shouldOpenAddSchedulePage() {
+
+        page.navigate(BASE_URL);
+
+        page.waitForLoadState();
+        page.waitForTimeout(3000);
+
+        page.click(".btn-add");
+
+        page.waitForLoadState();
+        page.waitForTimeout(2000);
+
+        assertThat(page.locator("h1"))
+                .containsText("Add New Record");
+
+        assertThat(page.locator("button[type='submit']"))
+                .containsText("Save");
+    }
+
+    @Test
+    void shouldCreateAndDeleteScheduleEntry() {
+
+        String customerName = "E2E Test Customer";
+
+        page.navigate(BASE_URL);
+
+        page.waitForLoadState();
+        page.waitForTimeout(3000);
+
+        page.click(".btn-add");
+
+        page.waitForLoadState();
+        page.waitForTimeout(2000);
+
+        page.locator("input[name='customer']")
+                .fill(customerName);
+
+        page.locator("input[name='couturier']")
+                .fill("Fashion Atelier");
+
+        page.locator("input[name='fittingDate']")
+                .fill("2026-05-07");
+
+        page.locator("input[name='itemModel']")
+                .fill("Evening Dress");
+
+        page.locator("input[name='sizes']")
+                .fill("M");
+
+        page.locator("input[name='fabrics']")
+                .fill("Silk");
+
+        page.locator("input[name='customerLevel']")
+                .fill("Gold");
+
+        page.locator("input[name='couturierExperience']")
+                .fill("10");
+
+        page.locator("input[name='atelierAddress']")
+                .fill("Kyiv");
+
+        page.locator("input[name='atelierPhone']")
+                .fill("380991112233");
+
+        page.click("button[type='submit']");
+
+        page.waitForLoadState();
+        page.waitForTimeout(3000);
+
+        assertThat(page.locator("body"))
+                .containsText(customerName);
+
+        page.locator("form:has-text('Delete')")
+                .first()
+                .locator("button")
+                .click();
+
+        page.waitForLoadState();
+        page.waitForTimeout(3000);
+
+        assertThat(page.locator("body"))
+                .not()
+                .containsText(customerName);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end UI testing support using Playwright for automated regression testing of the Fashion application.  
Introduced Playwright dependency in Maven, configured headless Chromium execution, and added E2E tests for opening the main page, navigating to the add page, and creating/deleting records through the UI.

### Related issue

Closes #43

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Added Playwright-based end-to-end UI tests for page navigation and CRUD flow validation.


